### PR TITLE
Tighten test selector scoping

### DIFF
--- a/cypress/integration/bonus.test.js
+++ b/cypress/integration/bonus.test.js
@@ -5,7 +5,7 @@ describe("Bonus", () => {
     cy.get("form").submit();
     cy.get("#todos").contains("say hello");
     cy.get(".Toastify__toast--success").contains("New todo added: say hello");
-    cy.contains("Remaining todos: 1")
+    cy.get(".Toastify__toast--default").contains("Remaining todos: 1");
   });
 
   it("adds a second todo and toast when submitted", () => {
@@ -16,7 +16,7 @@ describe("Bonus", () => {
     cy.get("form").submit();
     cy.get("#todos").contains("go away");
     cy.get(".Toastify__toast--success").contains("New todo added: go away");
-    cy.get(".Toastify__toast--default").contains("Remaining todos: 2")
+    cy.get(".Toastify__toast--default").contains("Remaining todos: 2");
   });
 
   it("deletes one todo with a toast when one is deleted", () => {
@@ -25,9 +25,9 @@ describe("Bonus", () => {
     cy.get("form").submit();
     cy.get("input").clear().type("go away");
     cy.get("form").submit();
-    cy.get("button").eq(4).click();
+    cy.get("#todos").find("button").eq(0).click();
     cy.get("#todos").contains("go away");
     cy.get(".Toastify__toast--error").contains("Todo deleted: say hello");
-    cy.get(".Toastify__toast--default").contains("Remaining todos: 1")
+    cy.get(".Toastify__toast--default").contains("Remaining todos: 1");
   });
 });

--- a/cypress/integration/index.test.js
+++ b/cypress/integration/index.test.js
@@ -23,7 +23,7 @@ describe("Index", () => {
     cy.get("form").submit();
     cy.get("input").clear().type("go away");
     cy.get("form").submit();
-    cy.get("button").eq(2).click();
+    cy.get("#todos").find("button").eq(0).click();
     cy.get("#todos").contains("go away");
     cy.get(".Toastify__toast--error").contains("Todo deleted: say hello");
   });


### PR DESCRIPTION
Made the selectors for buttons and toasts more specific to avoid flaky results.

**Button selectors**
- Todos have close buttons, but toasts on the page also have buttons, and users may or may not implement the bonus feature that adds more toasts to the page.
- This means the test cannot be sure of the _total_ number of buttons on the page for a correct solution.
- Currently we test deleting a todo by selecting all of the buttons on the page, then clicking on the ith button.
- That can have a flaky result since the number of buttons on the page can vary in correct solutions, depending on whether the bonus was implemented.

**Solution**: Scope the selector to `get` the `#todos` section first, then select the ith button in `#todos`. This should consistently select the close button of the specific todo we want to close.

**Toast selectors**
- One assertion on toasts was missing the class name selector, so I added it.